### PR TITLE
Fix long filenames missing `.` in extension

### DIFF
--- a/bdfr/file_name_formatter.py
+++ b/bdfr/file_name_formatter.py
@@ -154,6 +154,7 @@ class FileNameFormatter:
         max_path_length = max_path - len(ending) - len(str(root)) - 1
 
         out = Path(root, filename + ending)
+        safe_ending = re.match(r".*\..*", ending)
         while any(
             [
                 len(filename) > max_file_part_length_chars,
@@ -162,6 +163,8 @@ class FileNameFormatter:
             ]
         ):
             filename = filename[:-1]
+            if not safe_ending and filename[-1] != ".":
+                filename = filename[:-1] + "."
             out = Path(root, filename + ending)
 
         return out

--- a/tests/test_file_name_formatter.py
+++ b/tests/test_file_name_formatter.py
@@ -519,3 +519,19 @@ def test_name_submission(
     results = test_formatter.format_resource_paths(test_resources, Path())
     results = set([r[0].name for r in results])
     assert results == expected_names
+
+
+@pytest.mark.parametrize(
+    ("test_filename", "test_ending", "expected_end"),
+    (
+        ("A" * 300 + ".", "_1.mp4", "A_1.mp4"),
+        ("A" * 300 + ".", ".mp4", "A.mp4"),
+        ("A" * 300 + ".", "mp4", "A.mp4"),
+    ),
+)
+def test_shortened_file_name_ending(
+    test_filename: str, test_ending: str, expected_end: str, test_formatter: FileNameFormatter
+):
+    result = test_formatter.limit_file_name_length(test_filename, test_ending, Path("."))
+    assert result.name.endswith(expected_end)
+    assert len(str(result)) <= FileNameFormatter.find_max_path_length()


### PR DESCRIPTION
Fix for #753

> Long file names which end with `.` were having their path broken during shortening.
> e.g.; would be saved as `../../shortened_filenamemp4` instead of `../../shortened_filename.mp4`

Fixed the issue and added test coverage for this case.