### PR TITLE
Gfycat API

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,13 +2,18 @@
 # See https://pre-commit.com/hooks.html for more hooks
 
 repos:
+  - repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.12.1
+    hooks:
+      - id: validate-pyproject
+
   - repo: https://github.com/psf/black
-    rev: 22.12.0
+    rev: 23.1.0
     hooks:
       - id: black
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.11.4
+    rev: 5.12.0
     hooks:
       - id: isort
         name: isort (python)
@@ -23,3 +28,9 @@ repos:
     rev: v0.12.0
     hooks:
       - id: markdownlint
+
+  - repo: https://github.com/adamchainz/blacken-docs
+    rev: 1.13.0
+    hooks:
+      - id: blacken-docs
+        additional_dependencies: [black>=23.1.0]

--- a/bdfr/__main__.py
+++ b/bdfr/__main__.py
@@ -82,7 +82,7 @@ def _check_version(context, param, value):
     if not value or context.resilient_parsing:
         return
     current = __version__
-    latest = requests.get("https://pypi.org/pypi/bdfr/json").json()["info"]["version"]
+    latest = requests.get("https://pypi.org/pypi/bdfr/json", timeout=10).json()["info"]["version"]
     print(f"You are currently using v{current} the latest is v{latest}")
     context.exit()
 

--- a/bdfr/downloader.py
+++ b/bdfr/downloader.py
@@ -26,7 +26,7 @@ logger = logging.getLogger(__name__)
 
 def _calc_hash(existing_file: Path):
     chunk_size = 1024 * 1024
-    md5_hash = hashlib.md5()
+    md5_hash = hashlib.md5(usedforsecurity=False)
     with existing_file.open("rb") as file:
         chunk = file.read(chunk_size)
         while chunk:

--- a/bdfr/oauth2.py
+++ b/bdfr/oauth2.py
@@ -26,7 +26,9 @@ class OAuth2Authenticator:
     @staticmethod
     def _check_scopes(wanted_scopes: set[str]):
         response = requests.get(
-            "https://www.reddit.com/api/v1/scopes.json", headers={"User-Agent": "fetch-scopes test"}
+            "https://www.reddit.com/api/v1/scopes.json",
+            headers={"User-Agent": "fetch-scopes test"},
+            timeout=10,
         )
         known_scopes = [scope for scope, data in response.json().items()]
         known_scopes.append("*")

--- a/bdfr/resource.py
+++ b/bdfr/resource.py
@@ -49,7 +49,7 @@ class Resource:
             self.create_hash()
 
     def create_hash(self):
-        self.hash = hashlib.md5(self.content)
+        self.hash = hashlib.md5(self.content, usedforsecurity=False)
 
     def _determine_extension(self) -> Optional[str]:
         extension_pattern = re.compile(r".*(\..{3,5})$")
@@ -68,7 +68,7 @@ class Resource:
             max_wait_time = 300
         while True:
             try:
-                response = requests.get(url, headers=headers)
+                response = requests.get(url, headers=headers, timeout=10)
                 if re.match(r"^2\d{2}", str(response.status_code)) and response.content:
                     return response.content
                 elif response.status_code in (408, 429):

--- a/bdfr/site_downloaders/base_downloader.py
+++ b/bdfr/site_downloaders/base_downloader.py
@@ -28,10 +28,21 @@ class BaseDownloader(ABC):
     @staticmethod
     def retrieve_url(url: str, cookies: dict = None, headers: dict = None) -> requests.Response:
         try:
-            res = requests.get(url, cookies=cookies, headers=headers)
+            res = requests.get(url, cookies=cookies, headers=headers, timeout=10)
         except requests.exceptions.RequestException as e:
             logger.exception(e)
             raise SiteDownloaderError(f"Failed to get page {url}")
+        if res.status_code != 200:
+            raise ResourceNotFound(f"Server responded with {res.status_code} to {url}")
+        return res
+
+    @staticmethod
+    def post_url(url: str, cookies: dict = None, headers: dict = None, payload: dict = None) -> requests.Response:
+        try:
+            res = requests.post(url, cookies=cookies, headers=headers, json=payload, timeout=10)
+        except requests.exceptions.RequestException as e:
+            logger.exception(e)
+            raise SiteDownloaderError(f"Failed to post to {url}")
         if res.status_code != 200:
             raise ResourceNotFound(f"Server responded with {res.status_code} to {url}")
         return res

--- a/bdfr/site_downloaders/gallery.py
+++ b/bdfr/site_downloaders/gallery.py
@@ -42,7 +42,7 @@ class Gallery(BaseDownloader):
             possible_extensions = (".jpg", ".png", ".gif", ".gifv", ".jpeg")
             for extension in possible_extensions:
                 test_url = f"https://i.redd.it/{image_id}{extension}"
-                response = requests.head(test_url)
+                response = requests.head(test_url, timeout=10)
                 if response.status_code == 200:
                     out.append(test_url)
                     break

--- a/bdfr/site_downloaders/vidble.py
+++ b/bdfr/site_downloaders/vidble.py
@@ -37,7 +37,7 @@ class Vidble(BaseDownloader):
         if not re.search(r"vidble.com/(show/|album/|watch\?v)", url):
             url = re.sub(r"/(\w*?)$", r"/show/\1", url)
 
-        page = requests.get(url)
+        page = requests.get(url, timeout=10)
         soup = bs4.BeautifulSoup(page.text, "html.parser")
         content_div = soup.find("div", attrs={"id": "ContentPlaceHolder1_divContent"})
         images = content_div.find_all("img")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,12 +25,13 @@ classifiers = [
 dependencies = [
     "appdirs>=1.4.4",
     "beautifulsoup4>=4.10.0",
+    "cachetools>=5.3.0",
     "click>=8.0.0",
     "dict2xml>=1.7.0",
     "praw>=7.2.0",
     "pyyaml>=5.4.1",
-    "requests>=2.25.1",
-    "yt-dlp>=2022.11.11",
+    "requests>=2.28.2",
+    "yt-dlp>=2023.1.6",
 ]
 dynamic = ["version"]
 
@@ -41,11 +42,11 @@ data-files = {"config" = ["bdfr/default_config.cfg",]}
 
 [project.optional-dependencies]
 dev = [
-    "black>=22.12.0",
+    "black>=23.1.0",
     "Flake8-pyproject>=1.2.2",
-    "isort>=5.11.4",
-    "pre-commit>=2.20.0",
-    "pytest>=7.1.0",
+    "isort>=5.12.0",
+    "pre-commit>=3.0.4",
+    "pytest>=7.2.1",
     "tox>=3.27.1",
 ]
 

--- a/tests/site_downloaders/test_direct.py
+++ b/tests/site_downloaders/test_direct.py
@@ -14,10 +14,7 @@ from bdfr.site_downloaders.direct import Direct
     ("test_url", "expected_hash"),
     (
         ("https://i.redd.it/q6ebualjxzea1.jpg", "6ec154859c777cb401132bb991cb3635"),
-        (
-            "https://file-examples.com/wp-content/uploads/2017/11/file_example_MP3_700KB.mp3",
-            "35257826e20227a8a57d0e5a410e03c7",
-        ),
+        ("https://filesamples.com/samples/audio/mp3/sample3.mp3", "d30a2308f188cbb11d74cf20c357891c"),
     ),
 )
 def test_download_resource(test_url: str, expected_hash: str):

--- a/tests/site_downloaders/test_gfycat.py
+++ b/tests/site_downloaders/test_gfycat.py
@@ -10,6 +10,13 @@ from bdfr.site_downloaders.gfycat import Gfycat
 
 
 @pytest.mark.online
+def test_auth_cache():
+    auth1 = Gfycat._get_auth_token()
+    auth2 = Gfycat._get_auth_token()
+    assert auth1 == auth2
+
+
+@pytest.mark.online
 @pytest.mark.parametrize(
     ("test_url", "expected_url"),
     (

--- a/tests/site_downloaders/test_redgifs.py
+++ b/tests/site_downloaders/test_redgifs.py
@@ -10,6 +10,13 @@ from bdfr.resource import Resource
 from bdfr.site_downloaders.redgifs import Redgifs
 
 
+@pytest.mark.online
+def test_auth_cache():
+    auth1 = Redgifs._get_auth_token()
+    auth2 = Redgifs._get_auth_token()
+    assert auth1 == auth2
+
+
 @pytest.mark.parametrize(
     ("test_url", "expected"),
     (


### PR DESCRIPTION
Moves Gfycat to use API via site access key.

Adds cachetools as dependency to reuse API keys for Gfycat/Redgifs at 95% of their TTL. Include tests to verify caching.

Updates versions of requests/yt-dlp/black/isort/pytest.

Added default timeout to requests calls.

Adds validate-pyproject and blacken-docs to pre-commit as well as updates versions.