### PR TITLE
Update yt-dlp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,7 @@ dependencies = [
     "praw>=7.2.0",
     "pyyaml>=5.4.1",
     "requests>=2.28.2",
-    "yt-dlp>=2023.1.6",
+    "yt-dlp>=2023.2.17",
 ]
 dynamic = ["version"]
 

--- a/tests/site_downloaders/test_gfycat.py
+++ b/tests/site_downloaders/test_gfycat.py
@@ -21,12 +21,15 @@ def test_auth_cache():
     (
         ("https://gfycat.com/definitivecaninecrayfish", "https://giant.gfycat.com/DefinitiveCanineCrayfish.mp4"),
         ("https://gfycat.com/dazzlingsilkyiguana", "https://giant.gfycat.com/DazzlingSilkyIguana.mp4"),
-        ("https://gfycat.com/WearyComposedHairstreak", "https://thumbs4.redgifs.com/WearyComposedHairstreak.mp4"),
+        ("https://gfycat.com/WearyComposedHairstreak", "https://thumbs44.redgifs.com/WearyComposedHairstreak.mp4"),
         (
             "https://thumbs.gfycat.com/ComposedWholeBullfrog-size_restricted.gif",
-            "https://thumbs4.redgifs.com/ComposedWholeBullfrog.mp4",
+            "https://thumbs44.redgifs.com/ComposedWholeBullfrog.mp4",
         ),
-        ("https://giant.gfycat.com/ComposedWholeBullfrog.mp4", "https://thumbs4.redgifs.com/ComposedWholeBullfrog.mp4"),
+        (
+            "https://giant.gfycat.com/ComposedWholeBullfrog.mp4",
+            "https://thumbs44.redgifs.com/ComposedWholeBullfrog.mp4",
+        ),
     ),
 )
 def test_get_link(test_url: str, expected_url: str):


### PR DESCRIPTION
Update yt-dlp to 2023.2.17 as it contains updates to vreddit downloading for better coverage.