### PR TITLE
Partial revert of 98aa3d7

### DIFF
--- a/scripts/extract_failed_ids.sh
+++ b/scripts/extract_failed_ids.sh
@@ -8,9 +8,9 @@ else
 fi
 
 {
-    grep "Could not download submission" "$file" | awk "{ print $12 }" | rev | cut -c 2- | rev ;
-    grep "Failed to download resource" "$file" | awk "{ print $15 }" ;
-    grep "failed to download submission" "$file" | awk "{ print $14 }" | rev | cut -c 2- | rev ;
-    grep "Failed to write file" "$file" | awk "{ print $14 }" ;
-    grep "skipped due to disabled module" "$file" | awk "{ print $9 }" ;
+    grep "Could not download submission" "$file" | awk '{ print $12 }' | rev | cut -c 2- | rev ;
+    grep "Failed to download resource" "$file" | awk '{ print $15 }' ;
+    grep "failed to download submission" "$file" | awk '{ print $14 }' | rev | cut -c 2- | rev ;
+    grep "Failed to write file" "$file" | awk '{ print $14 }' ;
+    grep "skipped due to disabled module" "$file" | awk '{ print $9 }' ;
 }

--- a/scripts/extract_successful_ids.sh
+++ b/scripts/extract_successful_ids.sh
@@ -8,10 +8,10 @@ else
 fi
 
 {
-    grep "Downloaded submission" "$file" | awk "{ print $(NF-2) }" ;
-    grep "Resource hash" "$file" | awk "{ print $(NF-2) }" ;
-    grep "Download filter" "$file" | awk "{ print $(NF-3) }" ;
-    grep "already exists, continuing" "$file" | awk "{ print $(NF-3) }" ;
-    grep "Hard link made" "$file" | awk "{ print $(NF) }" ;
-    grep "filtered due to score" "$file" | awk "{ print $9 }"
+    grep "Downloaded submission" "$file" | awk '{ print $(NF-2) }' ;
+    grep "Resource hash" "$file" | awk '{ print $(NF-2) }' ;
+    grep "Download filter" "$file" | awk '{ print $(NF-3) }' ;
+    grep "already exists, continuing" "$file" | awk '{ print $(NF-3) }' ;
+    grep "Hard link made" "$file" | awk '{ print $(NF) }' ;
+    grep "filtered due to score" "$file" | awk '{ print $9 }' ;
 }

--- a/scripts/print_summary.sh
+++ b/scripts/print_summary.sh
@@ -7,10 +7,10 @@ else
     exit 1
 fi
 
-echo "Downloaded submissions: $( grep -c 'Downloaded submission' '$file' )"
-echo "Failed downloads: $( grep -c 'failed to download submission' '$file' )"
-echo "Files already downloaded: $( grep -c 'already exists, continuing' '$file' )"
-echo "Hard linked submissions: $( grep -c 'Hard link made' '$file' )"
-echo "Excluded submissions: $( grep -c 'in exclusion list' '$file' )"
-echo "Files with existing hash skipped: $( grep -c 'downloaded elsewhere' '$file' )"
-echo "Submissions from excluded subreddits: $( grep -c 'in skip list' '$file' )"
+echo "Downloaded submissions: $( grep -c 'Downloaded submission' "$file" )"
+echo "Failed downloads: $( grep -c 'failed to download submission' "$file" )"
+echo "Files already downloaded: $( grep -c 'already exists, continuing' "$file" )"
+echo "Hard linked submissions: $( grep -c 'Hard link made' "$file" )"
+echo "Excluded submissions: $( grep -c 'in exclusion list' "$file" )"
+echo "Files with existing hash skipped: $( grep -c 'downloaded elsewhere' "$file" )"
+echo "Submissions from excluded subreddits: $( grep -c 'in skip list' "$file" )"


### PR DESCRIPTION
Reverts some quote changes for awk commands as the prints do not function the same with double quotes when the variable number is over 10