### PR TITLE
Don't create directory if not needed

### DIFF
--- a/bdfr/downloader.py
+++ b/bdfr/downloader.py
@@ -123,12 +123,12 @@ class RedditDownloader(RedditConnector):
                 )
                 return
             resource_hash = res.hash.hexdigest()
-            destination.parent.mkdir(parents=True, exist_ok=True)
             if resource_hash in self.master_hash_list:
                 if self.args.no_dupes:
                     logger.info(f"Resource hash {resource_hash} from submission {submission.id} downloaded elsewhere")
                     return
                 elif self.args.make_hard_links:
+                    destination.parent.mkdir(parents=True, exist_ok=True)
                     try:
                         destination.hardlink_to(self.master_hash_list[resource_hash])
                     except AttributeError:
@@ -138,6 +138,7 @@ class RedditDownloader(RedditConnector):
                         f" in submission {submission.id}"
                     )
                     return
+            destination.parent.mkdir(parents=True, exist_ok=True)
             try:
                 with destination.open("wb") as file:
                     file.write(res.content)

--- a/tests/integration_tests/test_download_integration.py
+++ b/tests/integration_tests/test_download_integration.py
@@ -439,3 +439,17 @@ def test_cli_download_explicit_filename_restriction_scheme(test_args: list[str],
     assert result.exit_code == 0
     assert "Downloaded submission" in result.output
     assert "Forcing Windows-compatible filenames" in result.output
+
+
+@pytest.mark.online
+@pytest.mark.reddit
+@pytest.mark.skipif(not does_test_config_exist, reason="A test config file is required for integration tests")
+@pytest.mark.parametrize("test_args", (["--link", "ehqt2g", "--link", "ehtuv8", "--no-dupes"],))
+def test_cli_download_no_empty_dirs(test_args: list[str], tmp_path: Path):
+    runner = CliRunner()
+    test_args = create_basic_args_for_download_runner(test_args, tmp_path)
+    result = runner.invoke(cli, test_args)
+    assert result.exit_code == 0
+    assert "downloaded elsewhere" in result.output
+    assert Path(tmp_path, "EmpireDidNothingWrong").exists()
+    assert not Path(tmp_path, "StarWarsEU").exists()


### PR DESCRIPTION
Moves creation of parent directories after dupe check so directories are not made if not needed.