### PR TITLE
RUF lint

### DIFF
--- a/tests/integration_tests/test_archive_integration.py
+++ b/tests/integration_tests/test_archive_integration.py
@@ -20,7 +20,7 @@ def copy_test_config(run_path: Path):
 
 def create_basic_args_for_archive_runner(test_args: list[str], run_path: Path):
     copy_test_config(run_path)
-    out = [
+    out = [  # noqa: RUF005
         "archive",
         str(run_path),
         "-v",

--- a/tests/integration_tests/test_clone_integration.py
+++ b/tests/integration_tests/test_clone_integration.py
@@ -19,7 +19,7 @@ def copy_test_config(run_path: Path):
 
 def create_basic_args_for_cloner_runner(test_args: list[str], tmp_path: Path):
     copy_test_config(tmp_path)
-    out = [
+    out = [  # noqa: RUF005
         "clone",
         str(tmp_path),
         "-v",

--- a/tests/integration_tests/test_download_integration.py
+++ b/tests/integration_tests/test_download_integration.py
@@ -19,7 +19,7 @@ def copy_test_config(run_path: Path):
 
 def create_basic_args_for_download_runner(test_args: list[str], run_path: Path):
     copy_test_config(run_path)
-    out = [
+    out = [  # noqa: RUF005
         "download",
         str(run_path),
         "-v",

--- a/tests/test_file_name_formatter.py
+++ b/tests/test_file_name_formatter.py
@@ -55,7 +55,7 @@ def do_test_path_equality(result: Path, expected: str) -> bool:
         expected = Path(*expected)
     else:
         expected = Path(expected)
-    return str(result).endswith(str(expected))  # noqa: FURB123
+    return str(result).endswith(str(expected))  # noqa: FURB123,RUF100
 
 
 @pytest.fixture(scope="session")
@@ -427,8 +427,8 @@ def test_multilevel_folder_scheme(
         ("test", "test"),
         ("😍", "😍"),
         ("test😍", "test😍"),
-        ("test😍 ’", "test😍 ’"),
-        ("test😍 \\u2019", "test😍 ’"),
+        ("test😍 ’", "test😍 ’"),  # noqa: RUF001
+        ("test😍 \\u2019", "test😍 ’"),  # noqa: RUF001
         ("Using that real good [1\\4]", "Using that real good [1\\4]"),
     ),
 )
@@ -442,8 +442,8 @@ def test_preserve_emojis(test_name_string: str, expected: str, submission: Magic
 @pytest.mark.parametrize(
     ("test_string", "expected"),
     (
-        ("test \\u2019", "test ’"),
-        ("My cat\\u2019s paws are so cute", "My cat’s paws are so cute"),
+        ("test \\u2019", "test ’"),  # noqa: RUF001
+        ("My cat\\u2019s paws are so cute", "My cat’s paws are so cute"),  # noqa: RUF001
     ),
 )
 def test_convert_unicode_escapes(test_string: str, expected: str):


### PR DESCRIPTION
Adds coverage for RUF checks.

Adds noqa's for RUF005, as the suggested change seems to break testing on windows

Adds noqa's for RUF001 and RUF100 in formatter tests. RUF001's are expected unicode characters, RUF100 covers a Refurb noqa.