### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -408,7 +408,7 @@ Modules can be disabled through the command line interface for the BDFR or more 
 - `Vidble`
 - `VReddit` (Reddit Video Post)
 - `Youtube`
-- `YoutubeDlFallback`
+- `YtdlpFallback` (Youtube DL Fallback)
 
 ### Rate Limiting
 


### PR DESCRIPTION
The Readme says in the section `Disabling Modules` that you can disable the YT DL fallback downloader module with `YoutubeDlFallback`. But the module isn't disable with that option value.
The correct value would be the class name `YtdlpFallback` which is checked in 
https://github.com/aliparlakci/bulk-downloader-for-reddit/blob/8c293a46843c818bea2c2013db38191867993a14/bdfr/downloader.py#L103-L104
