### PR TITLE
Add ruff

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,7 +37,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        python -m pip install --upgrade pip Flake8-pyproject pytest pytest-cov
+        python -m pip install --upgrade pip pytest pytest-cov ruff
         pip install .
 
     - name: Make configuration for tests
@@ -46,16 +46,20 @@ jobs:
       run: |
         ./devscripts/configure${{ matrix.ext }}
 
-    - name: Lint with flake8
+    - name: Critical ruff lint
       run: |
-        flake8 . --select=E9,F63,F7,F82
+        ruff check --format=github --select=E9,F63,F7,F82 .
 
     - name: Test with pytest
       run: |
-        pytest -m 'not slow' --verbose --cov=./bdfr/ --cov-report term:skip-covered --cov-report html
+        pytest -m "not slow" --verbose --cov=./bdfr/ --cov-report term:skip-covered --cov-report html
 
     - name: Upload coverage report
       uses: actions/upload-artifact@v3
       with:
         name: coverage_report
         path: htmlcov/
+
+    - name: Full ruff lint
+      run: |
+        ruff check --format=github . --exit-zero

--- a/.gitignore
+++ b/.gitignore
@@ -128,6 +128,9 @@ venv.bak/
 .dmypy.json
 dmypy.json
 
+# ruff
+.ruff_cache/
+
 # Pyre type checker
 .pyre/
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -6,31 +6,29 @@ repos:
     rev: v0.12.1
     hooks:
       - id: validate-pyproject
+        name: validate-pyproject
 
   - repo: https://github.com/psf/black
     rev: 23.1.0
     hooks:
       - id: black
+        name: black
 
-  - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+  - repo: https://github.com/charliermarsh/ruff-pre-commit
+    rev: v0.0.254
     hooks:
-      - id: isort
-        name: isort (python)
-
-  - repo: https://github.com/pycqa/flake8
-    rev: 6.0.0
-    hooks:
-      - id: flake8
-        additional_dependencies: [Flake8-pyproject]
+      - id: ruff
+        name: ruff
 
   - repo: https://github.com/markdownlint/markdownlint
     rev: v0.12.0
     hooks:
       - id: markdownlint
+        name: markdownlint
 
   - repo: https://github.com/adamchainz/blacken-docs
     rev: 1.13.0
     hooks:
       - id: blacken-docs
+        name: blacken-docs
         additional_dependencies: [black>=23.1.0]

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -73,13 +73,12 @@ python3 -m pip install -e .[dev]
 The BDFR project uses several tools to manage the code of the project. These include:
 
 - [black](https://github.com/psf/black)
-- [flake8](https://github.com/john-hen/Flake8-pyproject)
-- [isort](https://github.com/PyCQA/isort)
 - [markdownlint (mdl)](https://github.com/markdownlint/markdownlint)
+- [ruff](https://github.com/charliermarsh/ruff)
 - [tox](https://tox.wiki/en/latest/)
 - [pre-commit](https://github.com/pre-commit/pre-commit)
 
-The first four tools are formatters. These change the code to the standards expected for the BDFR project. The configuration details for these tools are contained in the [pyproject.toml](../pyproject.toml) file for the project.
+The first three tools are formatters. These change the code to the standards expected for the BDFR project. The configuration details for these tools are contained in the [pyproject.toml](../pyproject.toml) file for the project.
 
 The tool `tox` is used to run tests and tools on demand and has the following environments:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,9 @@ data-files = {"config" = ["bdfr/default_config.cfg",]}
 [project.optional-dependencies]
 dev = [
     "black>=23.1.0",
-    "Flake8-pyproject>=1.2.2",
-    "isort>=5.12.0",
     "pre-commit>=3.0.4",
     "pytest>=7.2.1",
+    "ruff>=0.0.254",
     "tox>=3.27.1",
 ]
 
@@ -87,3 +86,16 @@ markers = [
     "slow: test is slow to run",
     "authenticated: test requires an authenticated Reddit instance",
 ]
+
+[tool.ruff]
+exclude = ["scripts/tests"]
+flake8-annotations = {"allow-star-arg-any" = true, "suppress-dummy-args" = true}
+flake8-pytest-style = {"parametrize-values-type" = "tuple", "mark-parentheses" = false}
+format = "grouped"
+ignore = ["ANN101","B904","N818","RET505"]
+line-length = 120
+per-file-ignores={"tests/*"=["ANN","S101","S105","S106"], "scripts/*"=["INP","S105","S106"]}
+select = ["ANN","B","BLE","E","ERA","F","I","ICN","INP","ISC","N","PT","PTH","Q","RUF","S","TID","UP","W","YTT"]
+show-fixes = true
+show-source = true
+target-version = "py39"


### PR DESCRIPTION
Adds ruff settings, tests and pre-commit.

Flake8 check replaced with ruff with same settings as test blockers but added full ruff lint at the end with non-blocking exit until the coverage and checks are complete/decided on

Replaces #795 as it got closed and I'm unable to re-open it.