### PR TITLE
Fix test config

### DIFF
--- a/devscripts/configure.ps1
+++ b/devscripts/configure.ps1
@@ -1,5 +1,5 @@
 if (-not ([string]::IsNullOrEmpty($env:REDDIT_TOKEN)))
 {
-    Copy-Item .\\bdfr\\default_config.cfg .\\test_config.cfg
-    Write-Output "`nuser_token = $env:REDDIT_TOKEN" >> ./test_config.cfg
+    Copy-Item .\\bdfr\\default_config.cfg .\\tests\\test_config.cfg
+    Write-Output "`nuser_token = $env:REDDIT_TOKEN" >> ./tests/test_config.cfg
 }

--- a/devscripts/configure.sh
+++ b/devscripts/configure.sh
@@ -2,6 +2,6 @@
 
 if [ -n "$REDDIT_TOKEN" ]
 then
-    cp ./bdfr/default_config.cfg ./test_config.cfg
-    echo -e "\nuser_token = $REDDIT_TOKEN" >> ./test_config.cfg
+    cp ./bdfr/default_config.cfg ./tests/test_config.cfg
+    echo -e "\nuser_token = $REDDIT_TOKEN" >> ./tests/test_config.cfg
 fi

--- a/tests/integration_tests/test_download_integration.py
+++ b/tests/integration_tests/test_download_integration.py
@@ -2,6 +2,7 @@
 
 import shutil
 from pathlib import Path
+from sys import platform
 from unittest.mock import MagicMock, patch
 
 import prawcore
@@ -425,6 +426,7 @@ def test_cli_download_user_reddit_server_error(test_args: list[str], response: i
 @pytest.mark.online
 @pytest.mark.reddit
 @pytest.mark.skipif(not does_test_config_exist, reason="A test config file is required for integration tests")
+@pytest.mark.skipif(platform == "darwin", reason="Test hangs on macos github")
 @pytest.mark.parametrize(
     "test_args",
     (


### PR DESCRIPTION
devscripts were copying the test config to an incorrect location causing all tests that required it to be skipped.