### PR TITLE
Added markdown format option

### DIFF
--- a/bdfr/__main__.py
+++ b/bdfr/__main__.py
@@ -65,7 +65,7 @@ _downloader_options = [
 _archiver_options = [
     click.option("--all-comments", is_flag=True, default=None),
     click.option("--comment-context", is_flag=True, default=None),
-    click.option("-f", "--format", type=click.Choice(("xml", "json", "yaml")), default=None),
+    click.option("-f", "--format", type=click.Choice(("xml", "json", "yaml", "md")), default=None),
 ]
 
 

--- a/tests/test_archiver.py
+++ b/tests/test_archiver.py
@@ -18,6 +18,7 @@ from bdfr.archiver import Archiver
         ("m3reby", "xml"),
         ("m3reby", "json"),
         ("m3reby", "yaml"),
+        ("m3reby", "md"),
     ),
 )
 def test_write_submission_json(test_submission_id: str, tmp_path: Path, test_format: str, reddit_instance: praw.Reddit):


### PR DESCRIPTION
fixes #816 


This is definitly not the most beautiful code I've written, but if gets the job done. Also I've run black, and it fixed only a few lines. 

I am still not 100% sure the code for building the markdown file should be in `archiver.py` but it still felt the most appropriate place. LMK if you think it should be refactored and put somewhere else.