### PR TITLE
Log initial link when using API

### DIFF
--- a/bdfr/site_downloaders/base_downloader.py
+++ b/bdfr/site_downloaders/base_downloader.py
@@ -25,7 +25,7 @@ class BaseDownloader(ABC):
         raise NotImplementedError
 
     @staticmethod
-    def retrieve_url(url: str, cookies: dict = None, headers: dict = None) -> requests.Response:
+    def retrieve_url(url: str, cookies: dict = None, headers: dict = None, initial: str = None) -> requests.Response:
         try:
             res = requests.get(url, cookies=cookies, headers=headers, timeout=10)
         except requests.exceptions.RequestException as e:
@@ -35,6 +35,7 @@ class BaseDownloader(ABC):
             logger.exception(e)
             raise SiteDownloaderError(f"Timeout reached attempting to get page {url}")
         if res.status_code != 200:
+            url = initial or url
             raise ResourceNotFound(f"Server responded with {res.status_code} at {url}")
         return res
 

--- a/bdfr/site_downloaders/gfycat.py
+++ b/bdfr/site_downloaders/gfycat.py
@@ -54,7 +54,7 @@ class Gfycat(Redgifs):
             "content-type": "application/json",
             "Authorization": f"Bearer {auth_token}",
         }
-        content = Gfycat.retrieve_url(f"https://api.gfycat.com/v1/gfycats/{gfycat_id}", headers=headers)
+        content = Gfycat.retrieve_url(f"https://api.gfycat.com/v1/gfycats/{gfycat_id}", headers=headers, initial=url)
 
         if content is None:
             raise SiteDownloaderError("Could not read the API source")

--- a/bdfr/site_downloaders/imgur.py
+++ b/bdfr/site_downloaders/imgur.py
@@ -41,10 +41,10 @@ class Imgur(BaseDownloader):
                 link = link.removesuffix("/")
             if re.search(r".*/(.*?)(gallery/|a/)", link):
                 imgur_id = re.match(r".*/(?:gallery/|a/)(.*?)(?:/.*|\..{3,4})?$", link).group(1)
-                link = f"https://api.imgur.com/3/album/{imgur_id}"
+                api = f"https://api.imgur.com/3/album/{imgur_id}"
             else:
                 imgur_id = re.match(r".*/(.*?)(?:_d)?(?:\..{0,})?$", link).group(1)
-                link = f"https://api.imgur.com/3/image/{imgur_id}"
+                api = f"https://api.imgur.com/3/image/{imgur_id}"
         except AttributeError:
             raise SiteDownloaderError(f"Could not extract Imgur ID from {link}")
 
@@ -54,7 +54,7 @@ class Imgur(BaseDownloader):
             "content-type": "application/json",
             "Authorization": "Client-ID 546c25a59c58ad7",
         }
-        res = Imgur.retrieve_url(link, headers=headers)
+        res = Imgur.retrieve_url(api, headers=headers, initial=link)
 
         try:
             image_dict = json.loads(res.text)

--- a/bdfr/site_downloaders/redgifs.py
+++ b/bdfr/site_downloaders/redgifs.py
@@ -53,7 +53,7 @@ class Redgifs(BaseDownloader):
             "content-type": "application/json",
             "Authorization": f"Bearer {auth_token}",
         }
-        content = Redgifs.retrieve_url(f"https://api.redgifs.com/v2/gifs/{redgif_id}", headers=headers)
+        content = Redgifs.retrieve_url(f"https://api.redgifs.com/v2/gifs/{redgif_id}", headers=headers, initial=url)
 
         if content is None:
             raise SiteDownloaderError("Could not read the page source")


### PR DESCRIPTION
Logs the initial link rather than the direct API link.

This will make checking if the link works through a regular browser easier in cases such as #755 