### PR TITLE
Refactor Imgur

### DIFF
--- a/bdfr/site_downloaders/imgur.py
+++ b/bdfr/site_downloaders/imgur.py
@@ -35,18 +35,20 @@ class Imgur(BaseDownloader):
         return out
 
     @staticmethod
-    def _get_data(link: str) -> dict:
+    def _get_id(link: str) -> str:
         try:
-            if link.endswith("/"):
-                link = link.removesuffix("/")
-            if re.search(r".*/(.*?)(gallery/|a/)", link):
-                imgur_id = re.match(r".*/(?:gallery/|a/)(.*?)(?:/.*|\..{3,4})?$", link).group(1)
-                link = f"https://api.imgur.com/3/album/{imgur_id}"
-            else:
-                imgur_id = re.match(r".*/(.*?)(?:_d)?(?:\..{0,})?$", link).group(1)
-                link = f"https://api.imgur.com/3/image/{imgur_id}"
+            imgur_id = re.search(r"imgur\.com/(?:a/|gallery/)?([a-zA-Z0-9]+)", link).group(1)
         except AttributeError:
             raise SiteDownloaderError(f"Could not extract Imgur ID from {link}")
+        return imgur_id
+
+    @staticmethod
+    def _get_data(link: str) -> dict:
+        imgur_id = Imgur._get_id(link)
+        if re.search(r"/(gallery|a)/", link):
+            api = f"https://api.imgur.com/3/album/{imgur_id}"
+        else:
+            api = f"https://api.imgur.com/3/image/{imgur_id}"
 
         headers = {
             "referer": "https://imgur.com/",
@@ -54,7 +56,7 @@ class Imgur(BaseDownloader):
             "content-type": "application/json",
             "Authorization": "Client-ID 546c25a59c58ad7",
         }
-        res = Imgur.retrieve_url(link, headers=headers)
+        res = Imgur.retrieve_url(api, headers=headers)
 
         try:
             image_dict = json.loads(res.text)

--- a/tests/site_downloaders/test_imgur.py
+++ b/tests/site_downloaders/test_imgur.py
@@ -8,7 +8,41 @@ from bdfr.resource import Resource
 from bdfr.site_downloaders.imgur import Imgur
 
 
+@pytest.mark.parametrize(
+    ("test_url", "expected"),
+    (
+        ("https://imgur.com/a/xWZsDDP", "xWZsDDP"),
+        ("https://imgur.com/gallery/IjJJdlC", "IjJJdlC"),
+        ("https://imgur.com/gallery/IjJJdlC/", "IjJJdlC"),
+        ("https://imgur.com/a/dcc84Gt", "dcc84Gt"),
+        ("https://imgur.com/a/eemHCCK", "eemHCCK"),
+        ("https://o.imgur.com/jZw9gq2.jpg", "jZw9gq2"),
+        ("https://i.imgur.com/lFJai6i.gifv", "lFJai6i"),
+        ("https://i.imgur.com/ywSyILa.gifv?", "ywSyILa"),
+        ("https://imgur.com/ubYwpbk.GIFV", "ubYwpbk"),
+        ("https://i.imgur.com/j1CNCZY.gifv", "j1CNCZY"),
+        ("https://i.imgur.com/uTvtQsw.gifv", "uTvtQsw"),
+        ("https://i.imgur.com/OGeVuAe.giff", "OGeVuAe"),
+        ("https://i.imgur.com/OGeVuAe.gift", "OGeVuAe"),
+        ("https://i.imgur.com/3SKrQfK.jpg?1", "3SKrQfK"),
+        ("https://i.imgur.com/cbivYRW.jpg?3", "cbivYRW"),
+        ("http://i.imgur.com/s9uXxlq.jpg?5.jpg", "s9uXxlq"),
+        ("http://i.imgur.com/s9uXxlqb.jpg", "s9uXxlqb"),
+        ("https://i.imgur.com/2TtN68l_d.webp", "2TtN68l"),
+        ("https://imgur.com/a/1qzfWtY/gifv", "1qzfWtY"),
+        ("https://imgur.com/a/1qzfWtY/mp4", "1qzfWtY"),
+        ("https://imgur.com/a/1qzfWtY/spqr", "1qzfWtY"),
+        ("https://i.imgur.com/expO7Rc.gifv", "expO7Rc"),
+        ("https://i.imgur.com/a/aqpiMuL.gif", "aqpiMuL"),
+    ),
+)
+def test_get_id(test_url: str, expected: str):
+    result = Imgur._get_id(test_url)
+    assert result == expected
+
+
 @pytest.mark.online
+@pytest.mark.slow
 @pytest.mark.parametrize(
     ("test_url", "expected_hashes"),
     (
@@ -24,32 +58,16 @@ from bdfr.site_downloaders.imgur import Imgur
                 "029c475ce01b58fdf1269d8771d33913",
             ),
         ),
-        (
-            "https://imgur.com/a/eemHCCK",
-            (
-                "9cb757fd8f055e7ef7aa88addc9d9fa5",
-                "b6cb6c918e2544e96fb7c07d828774b5",
-                "fb6c913d721c0bbb96aa65d7f560d385",
-            ),
-        ),
-        ("https://o.imgur.com/jZw9gq2.jpg", ("6d6ea9aa1d98827a05425338afe675bc",)),
-        ("https://i.imgur.com/lFJai6i.gifv", ("01a6e79a30bec0e644e5da12365d5071",)),
-        ("https://i.imgur.com/ywSyILa.gifv?", ("56d4afc32d2966017c38d98568709b45",)),
-        ("https://imgur.com/ubYwpbk.GIFV", ("d4a774aac1667783f9ed3a1bd02fac0c",)),
         ("https://i.imgur.com/j1CNCZY.gifv", ("ed63d7062bc32edaeea8b53f876a307c",)),
         ("https://i.imgur.com/uTvtQsw.gifv", ("46c86533aa60fc0e09f2a758513e3ac2",)),
         ("https://i.imgur.com/OGeVuAe.giff", ("77389679084d381336f168538793f218",)),
         ("https://i.imgur.com/OGeVuAe.gift", ("77389679084d381336f168538793f218",)),
-        ("https://i.imgur.com/3SKrQfK.jpg?1", ("aa299e181b268578979cad176d1bd1d0",)),
         ("https://i.imgur.com/cbivYRW.jpg?3", ("7ec6ceef5380cb163a1d498c359c51fd",)),
         ("http://i.imgur.com/s9uXxlq.jpg?5.jpg", ("338de3c23ee21af056b3a7c154e2478f",)),
         ("http://i.imgur.com/s9uXxlqb.jpg", ("338de3c23ee21af056b3a7c154e2478f",)),
-        ("https://i.imgur.com/2TtN68l_d.webp", ("6569ab9ad9fa68d93f6b408f112dd741",)),
         ("https://imgur.com/a/1qzfWtY/gifv", ("65fbc7ba5c3ed0e3af47c4feef4d3735",)),
         ("https://imgur.com/a/1qzfWtY/mp4", ("65fbc7ba5c3ed0e3af47c4feef4d3735",)),
         ("https://imgur.com/a/1qzfWtY/spqr", ("65fbc7ba5c3ed0e3af47c4feef4d3735",)),
-        ("https://i.imgur.com/expO7Rc.gifv", ("e309f98158fc98072eb2ae68f947f421",)),
-        ("https://i.imgur.com/a/aqpiMuL.gif", ("5b2a9a5218bf43dc26ba41389410c981",)),
     ),
 )
 def test_find_resources(test_url: str, expected_hashes: list[str]):

--- a/tests/site_downloaders/test_imgur.py
+++ b/tests/site_downloaders/test_imgur.py
@@ -11,29 +11,22 @@ from bdfr.site_downloaders.imgur import Imgur
 @pytest.mark.parametrize(
     ("test_url", "expected"),
     (
-        ("https://imgur.com/a/xWZsDDP", "xWZsDDP"),
-        ("https://imgur.com/gallery/IjJJdlC", "IjJJdlC"),
-        ("https://imgur.com/gallery/IjJJdlC/", "IjJJdlC"),
-        ("https://imgur.com/a/dcc84Gt", "dcc84Gt"),
-        ("https://imgur.com/a/eemHCCK", "eemHCCK"),
-        ("https://o.imgur.com/jZw9gq2.jpg", "jZw9gq2"),
-        ("https://i.imgur.com/lFJai6i.gifv", "lFJai6i"),
-        ("https://i.imgur.com/ywSyILa.gifv?", "ywSyILa"),
-        ("https://imgur.com/ubYwpbk.GIFV", "ubYwpbk"),
-        ("https://i.imgur.com/j1CNCZY.gifv", "j1CNCZY"),
-        ("https://i.imgur.com/uTvtQsw.gifv", "uTvtQsw"),
-        ("https://i.imgur.com/OGeVuAe.giff", "OGeVuAe"),
-        ("https://i.imgur.com/OGeVuAe.gift", "OGeVuAe"),
-        ("https://i.imgur.com/3SKrQfK.jpg?1", "3SKrQfK"),
-        ("https://i.imgur.com/cbivYRW.jpg?3", "cbivYRW"),
-        ("http://i.imgur.com/s9uXxlq.jpg?5.jpg", "s9uXxlq"),
-        ("http://i.imgur.com/s9uXxlqb.jpg", "s9uXxlqb"),
-        ("https://i.imgur.com/2TtN68l_d.webp", "2TtN68l"),
-        ("https://imgur.com/a/1qzfWtY/gifv", "1qzfWtY"),
-        ("https://imgur.com/a/1qzfWtY/mp4", "1qzfWtY"),
-        ("https://imgur.com/a/1qzfWtY/spqr", "1qzfWtY"),
-        ("https://i.imgur.com/expO7Rc.gifv", "expO7Rc"),
-        ("https://i.imgur.com/a/aqpiMuL.gif", "aqpiMuL"),
+        ("https://imgur.com/a/xWZsDDP", "xWZsDDP"),  # Gallery, /a/
+        ("https://imgur.com/gallery/IjJJdlC", "IjJJdlC"),  # Gallery, /gallery/
+        ("https://imgur.com/gallery/IjJJdlC/", "IjJJdlC"),  # Gallery, trailing /
+        ("https://o.imgur.com/jZw9gq2.jpg", "jZw9gq2"),  # Direct link, jpg, incorrect subdomain
+        ("https://i.imgur.com/lFJai6i.gifv", "lFJai6i"),  # Direct link, gifv
+        ("https://i.imgur.com/ywSyILa.gifv?", "ywSyILa"),  # Direct link, gifv, trailing ?
+        ("https://imgur.com/ubYwpbk.GIFV", "ubYwpbk"),  # No subdomain, uppercase gifv
+        ("https://i.imgur.com/OGeVuAe.giff", "OGeVuAe"),  # Direct link, incorrect extension
+        ("https://i.imgur.com/OGeVuAe.gift", "OGeVuAe"),  # Direct link, incorrect extension
+        ("https://i.imgur.com/3SKrQfK.jpg?1", "3SKrQfK"),  # Direct link, trainling ?1
+        ("https://i.imgur.com/cbivYRW.jpg?3", "cbivYRW"),  # Direct link, trailing ?3
+        ("http://i.imgur.com/s9uXxlq.jpg?5.jpg", "s9uXxlq"),  # Direct link, trailing ?5.jpg, http
+        ("http://i.imgur.com/s9uXxlqb.jpg", "s9uXxlqb"),  # Direct link, jpg, http
+        ("https://i.imgur.com/2TtN68l_d.webp", "2TtN68l"),  # Direct link, webp, _d thumbnail
+        ("https://imgur.com/a/1qzfWtY/gifv", "1qzfWtY"),  # Gallery, trailing filetype
+        ("https://imgur.com/a/1qzfWtY/spqr", "1qzfWtY"),  # Gallery, trailing non filetype
     ),
 )
 def test_get_id(test_url: str, expected: str):
@@ -46,11 +39,10 @@ def test_get_id(test_url: str, expected: str):
 @pytest.mark.parametrize(
     ("test_url", "expected_hashes"),
     (
-        ("https://imgur.com/a/xWZsDDP", ("f551d6e6b0fef2ce909767338612e31b",)),
-        ("https://imgur.com/gallery/IjJJdlC", ("740b006cf9ec9d6f734b6e8f5130bdab",)),
-        ("https://imgur.com/gallery/IjJJdlC/", ("740b006cf9ec9d6f734b6e8f5130bdab",)),
+        ("https://imgur.com/a/xWZsDDP", ("f551d6e6b0fef2ce909767338612e31b",)),  # Single image gallery
+        ("https://imgur.com/gallery/IjJJdlC", ("740b006cf9ec9d6f734b6e8f5130bdab",)),  # Single video gallery
         (
-            "https://imgur.com/a/dcc84Gt",
+            "https://imgur.com/a/dcc84Gt",  # Multiple image gallery
             (
                 "cf1158e1de5c3c8993461383b96610cf",
                 "28d6b791a2daef8aa363bf5a3198535d",
@@ -58,16 +50,26 @@ def test_get_id(test_url: str, expected: str):
                 "029c475ce01b58fdf1269d8771d33913",
             ),
         ),
-        ("https://i.imgur.com/j1CNCZY.gifv", ("ed63d7062bc32edaeea8b53f876a307c",)),
-        ("https://i.imgur.com/uTvtQsw.gifv", ("46c86533aa60fc0e09f2a758513e3ac2",)),
-        ("https://i.imgur.com/OGeVuAe.giff", ("77389679084d381336f168538793f218",)),
-        ("https://i.imgur.com/OGeVuAe.gift", ("77389679084d381336f168538793f218",)),
-        ("https://i.imgur.com/cbivYRW.jpg?3", ("7ec6ceef5380cb163a1d498c359c51fd",)),
-        ("http://i.imgur.com/s9uXxlq.jpg?5.jpg", ("338de3c23ee21af056b3a7c154e2478f",)),
-        ("http://i.imgur.com/s9uXxlqb.jpg", ("338de3c23ee21af056b3a7c154e2478f",)),
-        ("https://imgur.com/a/1qzfWtY/gifv", ("65fbc7ba5c3ed0e3af47c4feef4d3735",)),
-        ("https://imgur.com/a/1qzfWtY/mp4", ("65fbc7ba5c3ed0e3af47c4feef4d3735",)),
-        ("https://imgur.com/a/1qzfWtY/spqr", ("65fbc7ba5c3ed0e3af47c4feef4d3735",)),
+        ("https://i.imgur.com/j1CNCZY.gifv", ("ed63d7062bc32edaeea8b53f876a307c",)),  # Direct video link
+        ("https://i.imgur.com/uTvtQsw.gifv", ("46c86533aa60fc0e09f2a758513e3ac2",)),  # Direct video link
+        (
+            "https://i.imgur.com/OGeVuAe.giff",  # Direct video link, incorrect extension
+            ("77389679084d381336f168538793f218",),
+        ),
+        ("https://i.imgur.com/cbivYRW.jpg?3", ("7ec6ceef5380cb163a1d498c359c51fd",)),  # Direct image link, trailing ?3
+        (
+            "http://i.imgur.com/s9uXxlq.jpg?5.jpg",  # Direct image link, trailing ?5.jpg
+            ("338de3c23ee21af056b3a7c154e2478f",),
+        ),
+        ("http://i.imgur.com/s9uXxlqb.jpg", ("338de3c23ee21af056b3a7c154e2478f",)),  # Direct image link
+        (
+            "https://imgur.com/a/1qzfWtY/mp4",  # Single video gallery, web filetype request
+            ("65fbc7ba5c3ed0e3af47c4feef4d3735",),
+        ),
+        (
+            "https://imgur.com/a/1qzfWtY/spqr",  # Single video gallery, web filetype invalid
+            ("65fbc7ba5c3ed0e3af47c4feef4d3735",),
+        ),
     ),
 )
 def test_find_resources(test_url: str, expected_hashes: list[str]):


### PR DESCRIPTION
Refactor Imgur to be able to test getting ID and mark downloads as slow as they are currently rate limited through Github.