### PR TITLE
Connector test edge case

### DIFF
--- a/tests/test_connector.py
+++ b/tests/test_connector.py
@@ -3,6 +3,7 @@
 from collections.abc import Iterator
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Union
 from unittest.mock import MagicMock
 
 import praw
@@ -37,21 +38,23 @@ def downloader_mock(args: Configuration):
     return downloader_mock
 
 
-def assert_all_results_are_submissions(result_limit: int, results: list[Iterator]) -> list:
+def assert_all_results_are_submissions(result_limit: Union[int, None], results: list[Iterator]) -> list:
     results = [sub for res in results for sub in res]
     assert all([isinstance(res, praw.models.Submission) for res in results])
     assert not any([isinstance(m, MagicMock) for m in results])
     if result_limit is not None:
-        assert len(results) == result_limit
+        assert len(results) > 0
+        assert len(results) <= result_limit
     return results
 
 
-def assert_all_results_are_submissions_or_comments(result_limit: int, results: list[Iterator]) -> list:
+def assert_all_results_are_submissions_or_comments(result_limit: Union[int, None], results: list[Iterator]) -> list:
     results = [sub for res in results for sub in res]
     assert all([isinstance(res, (praw.models.Submission, praw.models.Comment)) for res in results])
     assert not any([isinstance(m, MagicMock) for m in results])
     if result_limit is not None:
-        assert len(results) == result_limit
+        assert len(results) > 0
+        assert len(results) <= result_limit
     return results
 
 


### PR DESCRIPTION
Covers an edge case of not having the exact amount as the limit, and now allows up to and including the limit.

Essentially covers if posts get deleted so the account being tested drops below the limit number which is still under the limit so should be able to pass.