### PR TITLE
Changes to how Redgifs temp auth tokens are handled

### DIFF
--- a/bdfr/__main__.py
+++ b/bdfr/__main__.py
@@ -7,7 +7,7 @@ import sys
 import click
 import requests
 
-from bdfr import __version__
+from bdfr.__init__ import __version__
 from bdfr.archiver import Archiver
 from bdfr.cloner import RedditCloner
 from bdfr.completion import Completion

--- a/bdfr/site_downloaders/base_downloader.py
+++ b/bdfr/site_downloaders/base_downloader.py
@@ -32,6 +32,8 @@ class BaseDownloader(ABC):
         except requests.exceptions.RequestException as e:
             logger.exception(e)
             raise SiteDownloaderError(f"Failed to get page {url}")
+        if res.status_code == 429:
+            raise ResourceNotFound("\n\nToo many requests\nTry again in a little while\n")
         if res.status_code != 200:
             raise ResourceNotFound(f"Server responded with {res.status_code} to {url}")
         return res


### PR DESCRIPTION
Hello.

I'm fairly new to programming (only about a year of python so far). 
I'm not entirely comfortable with pull requests yet and I apologize if some aspects are incorrect. 
Should I be attempting to merge into the `development` branch....?
Constructive criticism is appreciated.

I also apologize that my request is wordy. 
I prefer being thorough.

This pull request closes #939.

---

## Foreward

I have read both `ARCHITECTURE.md` and `CONTRIBUTING.md`. 
I believe this pull request fits in line with both of them, **with one caveat.**

This line declares that `bdfr` should be a stateless and my pull request technically is not.

https://github.com/aliparlakci/bulk-downloader-for-reddit/blob/7676ff06a3b0c31eb2af7e691412cd63e862deea/docs/ARCHITECTURE.md?plain=1#L7

Currently, temporary auth tokens are pulled from the Redgifs API _every time a link is checked_. 

https://github.com/aliparlakci/bulk-downloader-for-reddit/blob/7676ff06a3b0c31eb2af7e691412cd63e862deea/bdfr/site_downloaders/redgifs.py#L41-L43

I'm not sure when Redgifs changed their rate limiting (as downloads were working fine a few weeks ago), but they did.

My changes cache the temporary token using `os.path.join(tempfile.gettempdir(), "redgifs_token.txt")` and retrieve/save the `token` in three different instances.
1. If `redgifs_token.txt` does not exist.
2. If a `401` error occurs, meaning the token is invalid.
3. If `redgifs_token.txt` exists and is a working `auth_token`.

These tokens are good for 24 hours, as stated in the [Redgifs API docs](https://github.com/Redgifs/api/wiki/Temporary-tokens),

---

## Primary changes

**I will give bullet points on what I changed in each script.**
I'm apologize, for some reason I cannot comment on specific lines below. Still learning.

`bdfr/__main__.py`
* Adjusted `__version__` import. I received an error related to being unable to find `__version__` when attempting to use `pip install -e .`, so the import was adjusted. I can remove this if it's not a problem on your end. This was just required to get development working on my end.

`bdfr/downloader.py`
* Importing `redgifs` via `bdfr.site_downloaders`. I don't like doing this, but I couldn't figure out a way to only import/grab `redgifs` when necessary. You'd probably have a better solution to this.
* Added error handling specifically for `Redgifs` related `401 errors`. I'm using `str(e).startswith("Server responded with 401")`. It's lame, but it was yelling at me when I tried `e.status_code`. No clue why. This works though.

`bdfr/site_downloaders/base_downloader.py`
* Added error handling for `429` errors. It prints `Too many requests, Try again in a little while`

`bdfr/site_downloaders/redgifs.py`
* Importing `os` and `tempfile`, both necessary for creating/reading `redgifs_token.txt`.
* Added `TOKEN_FILE_PATH` to take care of caching the `auth_token`.
* Added three functions: `_load_token()`, `_save_token()`, and `_get_token()`. These handle pretty much exactly what their names state. I tried to cut out the fluff and only include what was necessary. I'm sure more could be trimmed off though.

---
## Expected output, tests, and considerations

### Expected output

If `redgifs_token.txt` is not found or a `401` error is received, `redgifs.py` will create the file and save the `token` to it.
I added formatting via print statements to let the user know what was going on.


> -=-=-=-=-=-=-=-=-=-=-=-
> Redgifs API token file not found, retrieving new token
> Attempting to retrieve new temporary Redgifs API token
> Writing Redgifs temporary API token to C:\Users\USERNAME\AppData\Local\Temp\redgifs_token.txt
> Success!
> 
> New temporary token is: eyJ0eXAiOiJKV1QiLCJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJhdXRoLXNlcnZpY2UiLCJpYXQiOjE3MDcwODU0NzgsImF1ZCI6Imh0dHBzOi8vYXBpLnJlZGdpZnMuY29tIiwiYXpwIjoiMTgyM2MzMWY3ZDMtNzQ1YS02NTg5LTAwMDUtZDhlOGZlMGE0NGMyIiwiZXhwIjoxNzA3MTcxODc4LCJzdWIsdaiOiJjbGllbnQvMTgyM2MzMWY3ZDMtNzQ1YS02NTg5LTAwMDUtZDhlOGZlMGE0NGMyIiwic2NvcGVzIjoicmVhZCIsInZhbGlkX2FkZHIiOiIxMDcuMTgyLjEzOS40MiIsInZhbGlkX2FnZW50IjoicHl0aG9uLXJlcXVlc3RzLzIuMzEuMCIsInJhdGUiOi0xLCJodHRwczovL3JlZGdpZnMuY29tL3Nlc3Npb24taWQiOiI2R3RFcVhFVnp0R0xvUlpBZzZaYTdTIn0.O3nK9dlnC_AmbmUF8dWPN3M5RYVA2wMDiQC0MGSZirJyesoE2YCvYik4aNF3lRyo73DjYdSCAKNSP3rVhis7Ji4bQazG3XI5bi9yvlXWgdaIZAljwIEzuqheValt_NpIlBbqHWvgJtdl_oOgyh5O4mNaE84ndRO4GD1FAUm5KawteI8eun-fd7ryY3mZhRWe9uDG3s2Mrdyg6r1EhwO4iiD05hHf66tL-GAlqAjPUCAdqLTI8Mj3Arn7kLnAcRlZfP2VRY9cy_gt-NKo7BmEgHsXCZz4h8W6qhlYzVhqVcAvGT1vAJkoZsXGXpj8jHs22Vdr3biLQWK38WUHdUWlKg
> -=-=-=-=-=-=-=-=-=-=-=-
> 

You could remove the `print` statements if you'd like but I think they look nice....

Redgifs temporary auth tokens are anonymous, read only, and only valid for 24 hours. I don't think there's any issue saving/displaying them. Though, I could be mistaken on that...?

I could remove the print statement that displays the `token` if you're not comfortable with it.
I made them compact in the code as well, so they're not too intrusive.

-=-

If `redgifs_token.txt` is found, but is incorrect (giving a `401` error code), the output is similar.

**BUT, the first attempted download does not go through.**
**I could not figure out how to fix this. If you could, I would greatly appreciate it.**
**This is the only bug that I could find.**
This does not crash the script.

-=-

There is no output if the `token` is correct.


### Tests

Command:
```
pytest -m "not reddit and not authenticated"
```

My changes failed on `27` tests, but a fresh `git clone` of the main branch failed on all of these tests as well.
Many of the failures take place due to `404` errors with the provided links.


### Considerations

The Redgifs test fails as well, but due to the bug mentioned above.
One link will hit a `401` error before it notices and grabs the `token`.
I'm not sure how to adjust for that.

Once per day, the first download will fail.
But the current implementation is _entirely broken_ due to the API changes. 
The lesser of two evils, I suppose...? It could probably be fixed, but I am currently out of brain juice. lol.

This was only tested on a Windows 10 machine. I'm not sure how Linux/Mac would handle the `os.path.join(tempfile.gettempdir(), "redgifs_token.txt")`. It _should_ work though.

I could also put in code to remove the `redgifs_token.txt` after use (not entirely sure how though), if you wanted it to be truly stateless.




